### PR TITLE
Revert "chore: replaced scripts by raw github actions"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,26 +14,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install SonarCloud scanner
+        run: |
+          dotnet tool install --global dotnet-sonarscanner
       - name: Docker Compose
         uses: isbang/compose-action@v1.5.0
         with:
           down-flags: "--volumes"
-      - name: Integration Tests
+      - name: Integration tests
         run: |
-          dotnet test \
-            --logger trx \
-            --logger "console;verbosity=detailed" \
-            --settings "runsettings.xml" \
-            --results-directory test-reports
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
-        with:
-          args: >
-            -Dsonar.organization=graduenz
-            -Dsonar.projectKey=graduenz_whoof-aspnetcore
-            -Dsonar.cs.opencover.reportsPaths=**/*/coverage.opencover.xml
-            -Dsonar.cs.vstest.reportsPaths=**/*/*.trx
-            -Dsonar.exclusions=samples/**/*.*,src/common/Whoof.Migrations/**/*.*,misc/**/*.*
+          ./scripts/start-tests.sh
+      - name: SonarCloud scan
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./scripts/start-sonarcloud.sh ${{ secrets.SONAR_TOKEN }} ${{ github.sha }}

--- a/tests/Whoof.Tests/Api/Controllers/PetVaccinationControllerTests.cs
+++ b/tests/Whoof.Tests/Api/Controllers/PetVaccinationControllerTests.cs
@@ -28,7 +28,7 @@ public class PetVaccinationControllerTests : BaseControllerTests
     {
         yield return new object[]
         {
-            new PetVaccinationDto { Id = IdPetVaccinationAppliedInTheFuture, AppliedAt = DateTimeOffset.UtcNow.AddDays(1) },
+            new PetVaccinationDto { Id = IdPetVaccinationAppliedInTheFuture, AppliedAt = TestDateTimeOffset.UtcNow.AddDays(1) },
             new[] { "'Applied At' must be less than or equal to current timestamp." }
         };
     }
@@ -51,10 +51,9 @@ public class PetVaccinationControllerTests : BaseControllerTests
         {
             var petVaccination = new PetVaccination
             {
-                Id = Guid.NewGuid(),
                 PetId = pet.Id,
                 VaccineId = v.Id,
-                AppliedAt = DateTimeOffset.UtcNow
+                AppliedAt = TestDateTimeOffset.UtcNow
             };
             
             petVaccinationDtos.Add(Mapper.Map<PetVaccinationDto>(petVaccination));
@@ -74,7 +73,7 @@ public class PetVaccinationControllerTests : BaseControllerTests
         result.TotalPages.Should().Be(1);
         result.Items.Should()
             .HaveCount(3)
-            .And.BeEquivalentTo(petVaccinationDtos, c => c.Excluding(m => m.AppliedAt));
+            .And.BeEquivalentTo(petVaccinationDtos, c => c.Excluding(m => m.Id));
     }
 
     [Fact]
@@ -115,7 +114,6 @@ public class PetVaccinationControllerTests : BaseControllerTests
         actualPetVaccination.Should()
             .NotBeNull().And
             .BeEquivalentTo(expectedPetVaccination, c => c
-                .Excluding(m => m.AppliedAt)
                 .ExcludingBaseFields());
     }
 
@@ -145,7 +143,7 @@ public class PetVaccinationControllerTests : BaseControllerTests
         {
             PetId = petId,
             VaccineId = vaccineId,
-            AppliedAt = DateTimeOffset.UtcNow.AddHours(-1)
+            AppliedAt = TestDateTimeOffset.UtcNow.AddHours(-1)
         };
 
         var beforeCount = await DbContext.PetVaccinations.CountAsync();
@@ -249,7 +247,7 @@ public class PetVaccinationControllerTests : BaseControllerTests
             Id = petVaccination.Id,
             PetId = petId,
             VaccineId = vaccineId,
-            AppliedAt = DateTimeOffset.UtcNow
+            AppliedAt = TestDateTimeOffset.UtcNow
         });
 
         // Act

--- a/tests/Whoof.Tests/Data/PreloadedData.cs
+++ b/tests/Whoof.Tests/Data/PreloadedData.cs
@@ -123,7 +123,7 @@ public static class PreloadedData
             for (var j = 0; j < numVaccinations; j++)
             {
                 var vaccine = vaccines[random.Next(vaccines.Count)];
-                var appliedAt = DateTimeOffset.UtcNow.AddDays(-random.Next(30, 365));
+                var appliedAt = TestDateTimeOffset.UtcNow.AddDays(-random.Next(30, 365));
 
                 var petVaccination = new PetVaccination
                 {

--- a/tests/Whoof.Tests/TestDateTimeOffset.cs
+++ b/tests/Whoof.Tests/TestDateTimeOffset.cs
@@ -1,0 +1,6 @@
+﻿namespace Whoof.Tests;
+
+public static class TestDateTimeOffset
+{
+    public static readonly DateTimeOffset UtcNow = new(2023, 08, 08, 13, 00, 00, TimeSpan.Zero);
+}


### PR DESCRIPTION
Found out that .NET projects can't use the action
Reference: https://github.com/SonarSource/sonarcloud-github-action